### PR TITLE
Cria funcionalidade de padronizar um nome completo

### DIFF
--- a/app/planilhas.py
+++ b/app/planilhas.py
@@ -1,0 +1,7 @@
+
+def padronizar_nome_completo(nome_completo_despadronizados):
+    """
+    Padroniza um nome completo:
+    - removendo os espaços no início e no fim
+    """
+    return nome_completo_despadronizados.strip()

--- a/app/planilhas.py
+++ b/app/planilhas.py
@@ -3,5 +3,18 @@ def padronizar_nome_completo(nome_completo_despadronizados):
     """
     Padroniza um nome completo:
     - removendo os espaços no início e no fim
+    - removendo espaços extras entre os nomes
+    - colocando em maiúsculas, inclusive nomes acentuados
     """
-    return nome_completo_despadronizados.strip()
+    padronizado = nome_completo_despadronizados.strip()
+    padronizado = padronizado.upper()
+    while True:
+        padronizado = padronizado.replace(" "*2, " ")
+        if "  " not in padronizado:
+            break
+    return padronizado
+
+
+if __name__ == "__main__":
+    nome = padronizar_nome_completo("Roberta")
+    print(nome)

--- a/tests/test_planilhas.py
+++ b/tests/test_planilhas.py
@@ -7,3 +7,27 @@ class TestPadronizarNomeCompleto(TestCase):
     def test_padronizar_nome_completo_retorna_nome_sem_espacos_extras_no_inicio_e_no_fim(self):
         resultado = padronizar_nome_completo("    ANA   \t\n")
         self.assertEqual("ANA", resultado)
+
+    def test_padronizar_nome_completo_retorna_nome_em_letras_maiusculas(self):
+        resultado = padronizar_nome_completo("maria")
+        self.assertEqual("MARIA", resultado)
+
+    def test_padronizar_nome_completo_retorna_nome_separado_por_apenas_um_espaco(self):
+        resultado = padronizar_nome_completo("Ana  Maria")
+        self.assertEqual("ANA MARIA", resultado)
+
+    def test_padronizar_nome_completo_retorna_nome_separado_por_apenas_um_espaco_se_o_nome_contiver_tres_espacos(self):
+        resultado = padronizar_nome_completo("Ana   Maria")
+        self.assertEqual("ANA MARIA", resultado)
+
+    def test_padronizar_nome_completo_retorna_nome_separado_por_apenas_um_espaco_se_o_nome_contiver_quatro_espacos(self):
+        resultado = padronizar_nome_completo("Ana" + " "*4 + "Maria")
+        self.assertEqual("ANA MARIA", resultado)
+
+    def test_padronizar_nome_completo_retorna_nome_padronizado_com_acentuacao(self):
+        resultado = padronizar_nome_completo("Patrícia")
+        self.assertEqual("PATRÍCIA", resultado)
+
+    def test_padronizar_nome_completo_retorna_nome_padronizado_com_til(self):
+        resultado = padronizar_nome_completo("João")
+        self.assertEqual("JOÃO", resultado)

--- a/tests/test_planilhas.py
+++ b/tests/test_planilhas.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+from app.planilhas import padronizar_nome_completo
+
+
+class TestPadronizarNomeCompleto(TestCase):
+
+    def test_padronizar_nome_completo_retorna_nome_sem_espacos_extras_no_inicio_e_no_fim(self):
+        resultado = padronizar_nome_completo("    ANA   \t\n")
+        self.assertEqual("ANA", resultado)


### PR DESCRIPTION
#### O que esse PR faz?
Cria funcionalidade de padronizar um nome completo, que é deixar os nomes em letras maíusculas e sem espaços extras no  início, fim e entre as palavras.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
No terminal do python, execute os seguintes comandos

```
from app import planilhas
planilhas.padronizar_nome_completo(NOME)
```

No lugar de `NOME`, use nomes que você desejar

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#3 

### Referências
n/a
